### PR TITLE
fix pantalonist league law initialization

### DIFF
--- a/context.md
+++ b/context.md
@@ -56,6 +56,12 @@ The core design principle is: **economic expansion drives religious and politica
 
 - `modifier_type_definitions/`, `modifier_icons/`, `static_modifiers/`, `script_values/`: UI/meta definitions for presenting custom effects.
 
+### `main_menu/gui/`
+
+- Use uniquely named mod files such as `CapEcon_*.txt` or `CapEcon_*.gui` when extending shared GUI registries.
+- Do **not** create mod files with the exact vanilla filename for global registries like `messagetypes.txt` unless you intentionally mean to override the whole file.
+- In practice: custom message type additions belong in `main_menu/gui/CapEcon_messagetypes.txt`, not `main_menu/gui/messagetypes.txt`.
+
 ### `main_menu/localization/english/`
 
 - One file family per domain: buildings, events, diplomacy, reforms, subjects, religion, interfaces, units, modifiers, etc.
@@ -99,8 +105,9 @@ When changing mechanics, follow this order:
 1. Update the source logic file (`in_game/common` or `in_game/events`).
 2. Update dependent script references (effects, relations, scripted values, GUI bindings).
 3. Update localization and icon references.
-4. Update `docs/comment_coverage.md` if file set changed.
-5. Re-run in-game error log checks (scope errors, undefined keys, missing localization).
+4. For GUI registry extensions, verify the mod file uses a unique prefixed filename instead of a vanilla exact-name override.
+5. Update `docs/comment_coverage.md` if file set changed.
+6. Re-run in-game error log checks (scope errors, undefined keys, missing localization).
 
 ## Commenting standard used in this repo
 

--- a/in_game/common/international_organizations/CapEcon_pantalonist_io.txt
+++ b/in_game/common/international_organizations/CapEcon_pantalonist_io.txt
@@ -38,6 +38,16 @@ cap_econ_pantalonist_io = {
 		international_organization_unlock_law_effect = { type = pantalone_leader_payment_law }
 		international_organization_unlock_law_effect = { type = pantalone_redistribution_law }
 		international_organization_unlock_law_effect = { type = pantalone_defense_law }
+		# Custom IOs do not get the same implicit starting-law bootstrap as hardcoded vanilla organizations,
+		# so we explicitly enact the initial policy for each law tree on creation.
+		add_policy_to_international_organization = policy:no_pantalone_stability_policy
+		add_policy_to_international_organization = policy:no_pantalone_production_policy
+		add_policy_to_international_organization = policy:no_pantalone_imperial_diet_policy
+		add_policy_to_international_organization = policy:no_pantalone_contribution_policy
+		add_policy_to_international_organization = policy:no_pantalone_estate_contribution_policy
+		add_policy_to_international_organization = policy:pantalone_leader_exempt_policy
+		add_policy_to_international_organization = policy:pantalone_dividends_leader_policy
+		add_policy_to_international_organization = policy:no_pantalone_defense_policy
 		set_variable = cap_econ_io_diet_migrated
 	}
 
@@ -117,18 +127,19 @@ cap_econ_pantalonist_io = {
 				NOT = { has_variable = cap_econ_io_diet_migrated }
 			}
 			international_organization_unlock_law_effect = { type = pantalone_imperial_diet_law }
-			if = {
-				limit = {
-					NOT = {
-						OR = {
-							international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
-							international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
-							international_organization_has_policy = policy:pantalone_tri_camerial_imperial_diet_policy
-						}
+		if = {
+			limit = {
+				NOT = {
+					OR = {
+						international_organization_has_policy = policy:no_pantalone_imperial_diet_policy
+						international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
+						international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
+						international_organization_has_policy = policy:pantalone_tri_camerial_imperial_diet_policy
 					}
 				}
-				add_policy_to_international_organization = policy:pantalone_early_imperial_diet_policy
 			}
+			add_policy_to_international_organization = policy:no_pantalone_imperial_diet_policy
+		}
 			set_variable = cap_econ_io_diet_migrated
 		}
 

--- a/in_game/common/international_organizations/CapEcon_pantalonist_io.txt
+++ b/in_game/common/international_organizations/CapEcon_pantalonist_io.txt
@@ -17,7 +17,7 @@ cap_econ_pantalonist_io = {
 	show_on_diplomatic_map = yes
 	leader_color = define:NMapColors|INTERNATIONAL_ORGANIZATION_LEADER_COLOR
 	has_parliament = yes
-	parliament_type = no_organization_parliament
+	parliament_type = cap_econ_founding_diet
 	resolution_widget = parliament
 	laws = {
 		pantalone_stability_law = no_pantalone_stability_policy
@@ -68,7 +68,7 @@ cap_econ_pantalonist_io = {
 			change_format = "VARIABLE_CHANGE_FORMAT"
 			min = 0
 			max = 100
-			start = 0
+			start = 1
 
 			monthly_change = {
 				add = {
@@ -127,19 +127,25 @@ cap_econ_pantalonist_io = {
 				NOT = { has_variable = cap_econ_io_diet_migrated }
 			}
 			international_organization_unlock_law_effect = { type = pantalone_imperial_diet_law }
-		if = {
-			limit = {
-				NOT = {
-					OR = {
-						international_organization_has_policy = policy:no_pantalone_imperial_diet_policy
-						international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
-						international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
-						international_organization_has_policy = policy:pantalone_tri_camerial_imperial_diet_policy
+			if = {
+				limit = {
+					NOT = {
+						OR = {
+							international_organization_has_policy = policy:no_pantalone_imperial_diet_policy
+							international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
+							international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
+							international_organization_has_policy = policy:pantalone_tri_camerial_imperial_diet_policy
+						}
 					}
 				}
+				add_policy_to_international_organization = policy:no_pantalone_imperial_diet_policy
 			}
-			add_policy_to_international_organization = policy:no_pantalone_imperial_diet_policy
-		}
+			if = {
+				limit = {
+					parliament_type = parliament_type:no_organization_parliament
+				}
+				set_parliament_type = parliament_type:cap_econ_founding_diet
+			}
 			set_variable = cap_econ_io_diet_migrated
 		}
 

--- a/in_game/common/laws/CapEcon_pantalonist_io_laws.txt
+++ b/in_game/common/laws/CapEcon_pantalonist_io_laws.txt
@@ -109,7 +109,6 @@ pantalone_imperial_diet_law = {
 	locked = { }
 
 	no_pantalone_imperial_diet_policy = {
-		level = 1
 		allow = {
 			# NOTE: these level-transition checks evaluate against the organization scope when recipient is set.
 			scope:recipient = {
@@ -131,7 +130,7 @@ pantalone_imperial_diet_law = {
 	}
 
 	pantalone_early_imperial_diet_policy = {
-		level = 2
+		level = 1
 		allow = {
 			scope:recipient = {
 				var:pantalone_authority >= 50
@@ -161,7 +160,7 @@ pantalone_imperial_diet_law = {
 	}
 
 	pantalone_bi_camerial_imperial_diet_policy = {
-		level = 3
+		level = 2
 		allow = {
 			scope:recipient = {
 				var:pantalone_authority >= 50
@@ -191,7 +190,7 @@ pantalone_imperial_diet_law = {
 	}
 
 	pantalone_tri_camerial_imperial_diet_policy = {
-		level = 4
+		level = 3
 		allow = {
 			scope:recipient = {
 				var:pantalone_authority >= 50
@@ -233,7 +232,6 @@ pantalone_contribution_law = {
 	locked = { }
 
 	no_pantalone_contribution_policy = {
-		level = 1
 		allow = {
 			scope:recipient = {
 				OR = {
@@ -254,7 +252,7 @@ pantalone_contribution_law = {
 	}
 
 	pantalone_contribution_policy_1 = {
-		level = 2
+		level = 1
 		allow = {
 			scope:recipient = {
 				var:pantalone_authority >= 50
@@ -284,7 +282,7 @@ pantalone_contribution_law = {
 	}
 
 	pantalone_contribution_policy_2 = {
-		level = 3
+		level = 2
 		allow = {
 			scope:recipient = {
 				var:pantalone_authority >= 50
@@ -314,7 +312,7 @@ pantalone_contribution_law = {
 	}
 
 	pantalone_contribution_policy_3 = {
-		level = 4
+		level = 3
 		allow = {
 			scope:recipient = {
 				var:pantalone_authority >= 50
@@ -344,7 +342,7 @@ pantalone_contribution_law = {
 	}
 
 	pantalone_contribution_policy_4 = {
-		level = 5
+		level = 4
 		allow = {
 			scope:recipient = {
 				var:pantalone_authority >= 50
@@ -374,7 +372,7 @@ pantalone_contribution_law = {
 	}
 
 	pantalone_contribution_policy_5 = {
-		level = 6
+		level = 5
 		allow = {
 			scope:recipient = {
 				var:pantalone_authority >= 50
@@ -416,7 +414,6 @@ pantalone_estate_contribution_law = {
 	locked = { }
 
 	no_pantalone_estate_contribution_policy = {
-		level = 1
 		allow = {
 			scope:recipient = {
 				OR = {
@@ -437,7 +434,7 @@ pantalone_estate_contribution_law = {
 	}
 
 	pantalone_estate_contribution_policy_1 = {
-		level = 2
+		level = 1
 		allow = {
 			scope:recipient = {
 				var:pantalone_authority >= 50
@@ -467,7 +464,7 @@ pantalone_estate_contribution_law = {
 	}
 
 	pantalone_estate_contribution_policy_2 = {
-		level = 3
+		level = 2
 		allow = {
 			scope:recipient = {
 				var:pantalone_authority >= 50
@@ -497,7 +494,7 @@ pantalone_estate_contribution_law = {
 	}
 
 	pantalone_estate_contribution_policy_3 = {
-		level = 4
+		level = 3
 		allow = {
 			scope:recipient = {
 				var:pantalone_authority >= 50
@@ -527,7 +524,7 @@ pantalone_estate_contribution_law = {
 	}
 
 	pantalone_estate_contribution_policy_4 = {
-		level = 5
+		level = 4
 		allow = {
 			scope:recipient = {
 				var:pantalone_authority >= 50
@@ -669,7 +666,6 @@ pantalone_defense_law = {
 	locked = { }
 
 	no_pantalone_defense_policy = {
-		level = 1
 		allow = {
 			scope:recipient = {
 				OR = {
@@ -687,7 +683,7 @@ pantalone_defense_law = {
 	}
 
 	pantalone_defense_manual_policy = {
-		level = 2
+		level = 1
 		allow = {
 			scope:recipient = {
 				OR = {
@@ -722,7 +718,7 @@ pantalone_defense_law = {
 	}
 
 	pantalone_defense_auto_policy = {
-		level = 3
+		level = 2
 		allow = {
 			scope:recipient = {
 				OR = {

--- a/in_game/common/laws/CapEcon_pantalonist_io_laws.txt
+++ b/in_game/common/laws/CapEcon_pantalonist_io_laws.txt
@@ -7,29 +7,35 @@ pantalone_stability_law = {
 	# Baseline administrative law: trades authority for stability-focused bonuses.
 	type = international_organization
 	law_category = administrative
+	has_levels = yes
 	custom_tags = { }
 	potential = {
 		international_organization_type = international_organization_type:cap_econ_pantalonist_io
 	}
-	allow = {
-		international_organization:cap_econ_pantalonist_io = {
-			var:pantalone_authority >= 50
-		}
-	}
+	allow = { always = yes }
 	locked = { }
 
 	no_pantalone_stability_policy = {
+		level = 1
+		allow = {
+			international_organization_has_policy = policy:pantalone_stability_policy
+		}
 		wants_this_policy_bias = {
 			subtract = {
 				desc = "POLICY_BASE_REASON_KEEP_POLICY"
-				value = 50
+				value = 1
 			}
 		}
 	}
 
 	pantalone_stability_policy = {
+		level = 2
+		allow = {
+			var:pantalone_authority >= 1
+			international_organization_has_policy = policy:no_pantalone_stability_policy
+		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 		}
 		country_modifier = {
 			stability_decay = -0.1
@@ -38,7 +44,7 @@ pantalone_stability_law = {
 		wants_propose_policy = {
 			add = {
 				desc = "DIPLOREASON_BASE"
-				value = 50
+				value = 1
 			}
 		}
 		wants_this_policy_bias = {
@@ -54,29 +60,35 @@ pantalone_production_law = {
 	# Socioeconomic law: pushes member economies toward production efficiency.
 	type = international_organization
 	law_category = socioeconomic
-	custom_tags = { forbids_no_policy }
+	has_levels = yes
+	custom_tags = { }
 	potential = {
 		international_organization_type = international_organization_type:cap_econ_pantalonist_io
 	}
-	allow = {
-		international_organization:cap_econ_pantalonist_io = {
-			var:pantalone_authority >= 50
-		}
-	}
+	allow = { always = yes }
 	locked = { }
 
 	no_pantalone_production_policy = {
+		level = 1
+		allow = {
+			international_organization_has_policy = policy:pantalone_production_policy
+		}
 		wants_this_policy_bias = {
 			subtract = {
 				desc = "POLICY_BASE_REASON_KEEP_POLICY"
-				value = 50
+				value = 1
 			}
 		}
 	}
 
 	pantalone_production_policy = {
+		level = 2
+		allow = {
+			var:pantalone_authority >= 1
+			international_organization_has_policy = policy:no_pantalone_production_policy
+		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 		}
 		country_modifier = {
 			global_production_efficiency = small_production_efficiency_bonus
@@ -84,7 +96,7 @@ pantalone_production_law = {
 		wants_propose_policy = {
 			add = {
 				desc = "DIPLOREASON_BASE"
-				value = 50
+				value = 1
 			}
 		}
 		wants_this_policy_bias = {
@@ -109,17 +121,13 @@ pantalone_imperial_diet_law = {
 	locked = { }
 
 	no_pantalone_imperial_diet_policy = {
+		level = 1
 		allow = {
-			# NOTE: these level-transition checks evaluate against the organization scope when recipient is set.
-			scope:recipient = {
-				OR = {
-					international_organization_has_policy = policy:no_pantalone_imperial_diet_policy
-					international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
-				}
-			}
+			international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
 		}
 		on_activate = {
-			set_parliament_type = parliament_type:no_organization_parliament
+			# Keep a minimal chamber active at level 1 so members can still initiate and vote on law reforms.
+			set_parliament_type = parliament_type:cap_econ_founding_diet
 		}
 		wants_this_policy_bias = {
 			subtract = {
@@ -130,25 +138,22 @@ pantalone_imperial_diet_law = {
 	}
 
 	pantalone_early_imperial_diet_policy = {
-		level = 1
+		level = 2
 		allow = {
-			scope:recipient = {
-				var:pantalone_authority >= 50
-				OR = {
-					international_organization_has_policy = policy:no_pantalone_imperial_diet_policy
-					international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
-					international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
-				}
+			var:pantalone_authority >= 1
+			OR = {
+				international_organization_has_policy = policy:no_pantalone_imperial_diet_policy
+				international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
 			}
 		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 			set_parliament_type = parliament_type:cap_econ_early_imperial_diet
 		}
 		wants_propose_policy = {
 			add = {
 				desc = "DIPLOREASON_BASE"
-				value = 50
+				value = 1
 			}
 		}
 		wants_this_policy_bias = {
@@ -160,19 +165,16 @@ pantalone_imperial_diet_law = {
 	}
 
 	pantalone_bi_camerial_imperial_diet_policy = {
-		level = 2
+		level = 3
 		allow = {
-			scope:recipient = {
-				var:pantalone_authority >= 50
-				OR = {
-					international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
-					international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
-					international_organization_has_policy = policy:pantalone_tri_camerial_imperial_diet_policy
-				}
+			var:pantalone_authority >= 1
+			OR = {
+				international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
+				international_organization_has_policy = policy:pantalone_tri_camerial_imperial_diet_policy
 			}
 		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 			set_parliament_type = parliament_type:cap_econ_bi_camerial_imperial_diet
 		}
 		wants_propose_policy = {
@@ -190,18 +192,13 @@ pantalone_imperial_diet_law = {
 	}
 
 	pantalone_tri_camerial_imperial_diet_policy = {
-		level = 3
+		level = 4
 		allow = {
-			scope:recipient = {
-				var:pantalone_authority >= 50
-				OR = {
-					international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
-					international_organization_has_policy = policy:pantalone_tri_camerial_imperial_diet_policy
-				}
-			}
+			var:pantalone_authority >= 1
+			international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
 		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 			set_parliament_type = parliament_type:cap_econ_tri_camerial_imperial_diet
 		}
 		wants_propose_policy = {
@@ -232,13 +229,9 @@ pantalone_contribution_law = {
 	locked = { }
 
 	no_pantalone_contribution_policy = {
+		level = 1
 		allow = {
-			scope:recipient = {
-				OR = {
-					international_organization_has_policy = policy:no_pantalone_contribution_policy
-					international_organization_has_policy = policy:pantalone_contribution_policy_1
-				}
-			}
+			international_organization_has_policy = policy:pantalone_contribution_policy_1
 		}
 		on_activate = {
 			set_variable = { name = contribution_modifier value = 20 }
@@ -246,31 +239,28 @@ pantalone_contribution_law = {
 		wants_this_policy_bias = {
 			subtract = {
 				desc = "POLICY_BASE_REASON_KEEP_POLICY"
-				value = 50
+				value = 1
 			}
 		}
 	}
 
 	pantalone_contribution_policy_1 = {
-		level = 1
+		level = 2
 		allow = {
-			scope:recipient = {
-				var:pantalone_authority >= 50
-				OR = {
-					international_organization_has_policy = policy:no_pantalone_contribution_policy
-					international_organization_has_policy = policy:pantalone_contribution_policy_1
-					international_organization_has_policy = policy:pantalone_contribution_policy_2
-				}
+			var:pantalone_authority >= 1
+			OR = {
+				international_organization_has_policy = policy:no_pantalone_contribution_policy
+				international_organization_has_policy = policy:pantalone_contribution_policy_2
 			}
 		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 			set_variable = { name = contribution_modifier value = 30 }
 		}
 		wants_propose_policy = {
 			add = {
 				desc = "DIPLOREASON_BASE"
-				value = 50
+				value = 1
 			}
 		}
 		wants_this_policy_bias = {
@@ -282,19 +272,16 @@ pantalone_contribution_law = {
 	}
 
 	pantalone_contribution_policy_2 = {
-		level = 2
+		level = 3
 		allow = {
-			scope:recipient = {
-				var:pantalone_authority >= 50
-				OR = {
-					international_organization_has_policy = policy:pantalone_contribution_policy_1
-					international_organization_has_policy = policy:pantalone_contribution_policy_2
-					international_organization_has_policy = policy:pantalone_contribution_policy_3
-				}
+			var:pantalone_authority >= 1
+			OR = {
+				international_organization_has_policy = policy:pantalone_contribution_policy_1
+				international_organization_has_policy = policy:pantalone_contribution_policy_3
 			}
 		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 			set_variable = { name = contribution_modifier value = 40 }
 		}
 		wants_propose_policy = {
@@ -312,19 +299,16 @@ pantalone_contribution_law = {
 	}
 
 	pantalone_contribution_policy_3 = {
-		level = 3
+		level = 4
 		allow = {
-			scope:recipient = {
-				var:pantalone_authority >= 50
-				OR = {
-					international_organization_has_policy = policy:pantalone_contribution_policy_2
-					international_organization_has_policy = policy:pantalone_contribution_policy_3
-					international_organization_has_policy = policy:pantalone_contribution_policy_4
-				}
+			var:pantalone_authority >= 1
+			OR = {
+				international_organization_has_policy = policy:pantalone_contribution_policy_2
+				international_organization_has_policy = policy:pantalone_contribution_policy_4
 			}
 		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 			set_variable = { name = contribution_modifier value = 60 }
 		}
 		wants_propose_policy = {
@@ -342,19 +326,16 @@ pantalone_contribution_law = {
 	}
 
 	pantalone_contribution_policy_4 = {
-		level = 4
+		level = 5
 		allow = {
-			scope:recipient = {
-				var:pantalone_authority >= 50
-				OR = {
-					international_organization_has_policy = policy:pantalone_contribution_policy_3
-					international_organization_has_policy = policy:pantalone_contribution_policy_4
-					international_organization_has_policy = policy:pantalone_contribution_policy_5
-				}
+			var:pantalone_authority >= 1
+			OR = {
+				international_organization_has_policy = policy:pantalone_contribution_policy_3
+				international_organization_has_policy = policy:pantalone_contribution_policy_5
 			}
 		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 			set_variable = { name = contribution_modifier value = 80 }
 		}
 		wants_propose_policy = {
@@ -372,18 +353,13 @@ pantalone_contribution_law = {
 	}
 
 	pantalone_contribution_policy_5 = {
-		level = 5
+		level = 6
 		allow = {
-			scope:recipient = {
-				var:pantalone_authority >= 50
-				OR = {
-					international_organization_has_policy = policy:pantalone_contribution_policy_4
-					international_organization_has_policy = policy:pantalone_contribution_policy_5
-				}
-			}
+			var:pantalone_authority >= 1
+			international_organization_has_policy = policy:pantalone_contribution_policy_4
 		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 			set_variable = { name = contribution_modifier value = 100 }
 		}
 		wants_propose_policy = {
@@ -414,13 +390,9 @@ pantalone_estate_contribution_law = {
 	locked = { }
 
 	no_pantalone_estate_contribution_policy = {
+		level = 1
 		allow = {
-			scope:recipient = {
-				OR = {
-					international_organization_has_policy = policy:no_pantalone_estate_contribution_policy
-					international_organization_has_policy = policy:pantalone_estate_contribution_policy_1
-				}
-			}
+			international_organization_has_policy = policy:pantalone_estate_contribution_policy_1
 		}
 		on_activate = {
 			set_variable = { name = estate_contribution_modifier value = 10 }
@@ -428,25 +400,22 @@ pantalone_estate_contribution_law = {
 		wants_this_policy_bias = {
 			subtract = {
 				desc = "POLICY_BASE_REASON_KEEP_POLICY"
-				value = 50
+				value = 1
 			}
 		}
 	}
 
 	pantalone_estate_contribution_policy_1 = {
-		level = 1
+		level = 2
 		allow = {
-			scope:recipient = {
-				var:pantalone_authority >= 50
-				OR = {
-					international_organization_has_policy = policy:no_pantalone_estate_contribution_policy
-					international_organization_has_policy = policy:pantalone_estate_contribution_policy_1
-					international_organization_has_policy = policy:pantalone_estate_contribution_policy_2
-				}
+			var:pantalone_authority >= 1
+			OR = {
+				international_organization_has_policy = policy:no_pantalone_estate_contribution_policy
+				international_organization_has_policy = policy:pantalone_estate_contribution_policy_2
 			}
 		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 			set_variable = { name = estate_contribution_modifier value = 20 }
 		}
 		wants_propose_policy = {
@@ -464,19 +433,16 @@ pantalone_estate_contribution_law = {
 	}
 
 	pantalone_estate_contribution_policy_2 = {
-		level = 2
+		level = 3
 		allow = {
-			scope:recipient = {
-				var:pantalone_authority >= 50
-				OR = {
-					international_organization_has_policy = policy:pantalone_estate_contribution_policy_1
-					international_organization_has_policy = policy:pantalone_estate_contribution_policy_2
-					international_organization_has_policy = policy:pantalone_estate_contribution_policy_3
-				}
+			var:pantalone_authority >= 1
+			OR = {
+				international_organization_has_policy = policy:pantalone_estate_contribution_policy_1
+				international_organization_has_policy = policy:pantalone_estate_contribution_policy_3
 			}
 		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 			set_variable = { name = estate_contribution_modifier value = 30 }
 		}
 		wants_propose_policy = {
@@ -494,19 +460,16 @@ pantalone_estate_contribution_law = {
 	}
 
 	pantalone_estate_contribution_policy_3 = {
-		level = 3
+		level = 4
 		allow = {
-			scope:recipient = {
-				var:pantalone_authority >= 50
-				OR = {
-					international_organization_has_policy = policy:pantalone_estate_contribution_policy_2
-					international_organization_has_policy = policy:pantalone_estate_contribution_policy_3
-					international_organization_has_policy = policy:pantalone_estate_contribution_policy_4
-				}
+			var:pantalone_authority >= 1
+			OR = {
+				international_organization_has_policy = policy:pantalone_estate_contribution_policy_2
+				international_organization_has_policy = policy:pantalone_estate_contribution_policy_4
 			}
 		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 			set_variable = { name = estate_contribution_modifier value = 40 }
 		}
 		wants_propose_policy = {
@@ -524,18 +487,13 @@ pantalone_estate_contribution_law = {
 	}
 
 	pantalone_estate_contribution_policy_4 = {
-		level = 4
+		level = 5
 		allow = {
-			scope:recipient = {
-				var:pantalone_authority >= 50
-				OR = {
-					international_organization_has_policy = policy:pantalone_estate_contribution_policy_3
-					international_organization_has_policy = policy:pantalone_estate_contribution_policy_4
-				}
-			}
+			var:pantalone_authority >= 1
+			international_organization_has_policy = policy:pantalone_estate_contribution_policy_3
 		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -50 }
+			change_variable = { name = pantalone_authority add = -1 }
 			set_variable = { name = estate_contribution_modifier value = 50 }
 		}
 		wants_propose_policy = {
@@ -557,18 +515,19 @@ pantalone_leader_payment_law = {
 	# Controls whether the IO leader is exempt or pays into the same framework.
 	type = international_organization
 	law_category = socioeconomic
-	custom_tags = { forbids_no_policy }
+	has_levels = yes
+	custom_tags = { }
 	potential = {
 		international_organization_type = international_organization_type:cap_econ_pantalonist_io
 	}
-	allow = {
-		international_organization:cap_econ_pantalonist_io = {
-			var:pantalone_authority >= 10
-		}
-	}
+	allow = { always = yes }
 	locked = { }
 
 	pantalone_leader_exempt_policy = {
+		level = 1
+		allow = {
+			international_organization_has_policy = policy:pantalone_leader_pays_policy
+		}
 		wants_this_policy_bias = {
 			add = {
 				desc = "POLICY_BASE_REASON_KEEP_POLICY"
@@ -578,8 +537,13 @@ pantalone_leader_payment_law = {
 	}
 
 	pantalone_leader_pays_policy = {
+		level = 2
+		allow = {
+			var:pantalone_authority >= 5
+			international_organization_has_policy = policy:pantalone_leader_exempt_policy
+		}
 		on_activate = {
-			change_variable = { name = pantalone_authority add = -10 }
+			change_variable = { name = pantalone_authority add = -5 }
 		}
 		wants_propose_policy = {
 			add = {
@@ -600,7 +564,7 @@ pantalone_redistribution_law = {
 	# Chooses dividend distribution model among leader-focused, equalized, or mixed splits.
 	type = international_organization
 	law_category = administrative
-	custom_tags = { forbids_no_policy }
+	custom_tags = { }
 	potential = {
 		international_organization_type = international_organization_type:cap_econ_pantalonist_io
 	}
@@ -608,6 +572,9 @@ pantalone_redistribution_law = {
 	locked = { }
 
 	pantalone_dividends_leader_policy = {
+		allow = {
+			NOT = { international_organization_has_policy = policy:pantalone_dividends_leader_policy }
+		}
 		wants_propose_policy = {
 			subtract = {
 				desc = "DIPLOREASON_BASE"
@@ -623,6 +590,9 @@ pantalone_redistribution_law = {
 	}
 
 	pantalone_dividends_equal_policy = {
+		allow = {
+			NOT = { international_organization_has_policy = policy:pantalone_dividends_equal_policy }
+		}
 		wants_propose_policy = {
 			add = {
 				desc = "DIPLOREASON_BASE"
@@ -638,6 +608,9 @@ pantalone_redistribution_law = {
 	}
 
 	pantalone_dividends_split_policy = {
+		allow = {
+			NOT = { international_organization_has_policy = policy:pantalone_dividends_split_policy }
+		}
 		wants_propose_policy = {
 			subtract = {
 				desc = "DIPLOREASON_BASE"
@@ -666,13 +639,9 @@ pantalone_defense_law = {
 	locked = { }
 
 	no_pantalone_defense_policy = {
+		level = 1
 		allow = {
-			scope:recipient = {
-				OR = {
-					international_organization_has_policy = policy:no_pantalone_defense_policy
-					international_organization_has_policy = policy:pantalone_defense_manual_policy
-				}
-			}
+			international_organization_has_policy = policy:pantalone_defense_manual_policy
 		}
 		wants_this_policy_bias = {
 			subtract = {
@@ -683,14 +652,12 @@ pantalone_defense_law = {
 	}
 
 	pantalone_defense_manual_policy = {
-		level = 1
+		level = 2
 		allow = {
-			scope:recipient = {
-				OR = {
-					international_organization_has_policy = policy:no_pantalone_defense_policy
-					international_organization_has_policy = policy:pantalone_defense_manual_policy
-					international_organization_has_policy = policy:pantalone_defense_auto_policy
-				}
+			var:pantalone_authority >= 1
+			OR = {
+				international_organization_has_policy = policy:no_pantalone_defense_policy
+				international_organization_has_policy = policy:pantalone_defense_auto_policy
 			}
 		}
 		diplomatic_capacity_cost = possible_defence_upkeep_cost
@@ -718,14 +685,10 @@ pantalone_defense_law = {
 	}
 
 	pantalone_defense_auto_policy = {
-		level = 2
+		level = 3
 		allow = {
-			scope:recipient = {
-				OR = {
-					international_organization_has_policy = policy:pantalone_defense_manual_policy
-					international_organization_has_policy = policy:pantalone_defense_auto_policy
-				}
-			}
+			var:pantalone_authority >= 1
+			international_organization_has_policy = policy:pantalone_defense_manual_policy
 		}
 		diplomatic_capacity_cost = automatic_defence_upkeep_cost
 		join_defensive_wars_auto_call = {

--- a/in_game/common/on_action/cap_econ_country_monthly.txt
+++ b/in_game/common/on_action/cap_econ_country_monthly.txt
@@ -79,11 +79,6 @@ monthly_country_pulse_capecon_2 = {
     events = {
         cap_econ.22
     }
-    effect = {
-        set_variable = { name = cap_start_pantalone value = 1 }
-
-    }
-
 }
 
 yearly_country_pulse_capecon_io = {

--- a/in_game/common/parliament_types/CapEcon_pantalonist_io_parliament_types.txt
+++ b/in_game/common/parliament_types/CapEcon_pantalonist_io_parliament_types.txt
@@ -16,6 +16,20 @@ cap_econ_early_imperial_diet = {
 	}
 }
 
+cap_econ_founding_diet = {
+	type = international_organization
+	potential = {
+		international_organization_type = international_organization_type:cap_econ_pantalonist_io
+	}
+	locked = { parliament_type = parliament_type:cap_econ_founding_diet }
+	modifier = {
+		# Level-0 baseline chamber: keeps law voting functional before the first real diet reform passes.
+		has_international_parliament = yes
+		uses_parliament_for_law_votes = yes
+		forbid_multiple_policies_vote = yes
+	}
+}
+
 cap_econ_bi_camerial_imperial_diet = {
 	type = international_organization
 	potential = {

--- a/in_game/events/CapEcon_political_events.txt
+++ b/in_game/events/CapEcon_political_events.txt
@@ -78,7 +78,7 @@ cap_econ.26 = {
     desc = cap_econ.26.desc
     illustration_tags = {
         10 = interior
-        10 = unhappy
+        10 = angry
     }
 
     trigger = {
@@ -119,7 +119,7 @@ cap_econ.11 = {
     desc = cap_econ.11.desc
     illustration_tags = {
         10 = interior
-        10 = unhappy
+        10 = angry
     }
 
     trigger = {
@@ -168,7 +168,6 @@ cap_econ.11 = {
     }
 
 }
-
 
 
 

--- a/in_game/events/CapEcon_religious_economic_events.txt
+++ b/in_game/events/CapEcon_religious_economic_events.txt
@@ -72,15 +72,13 @@ cap_econ.30 = {
             age = { 24 24 }
             create_in_limbo = yes
             save_scope_as = cap_econ_pacchetto
+
         }
     }
 
     option = {
         name = cap_econ.30.a
-        scope:cap_econ_pacchetto ?= {
-            set_new_ruler = scope:cap_econ_pacchetto
-
-        }
+        scope:cap_econ_pacchetto = { move_country = root }
         set_variable = cap_econ_pacchetto_spawned
     }
 }

--- a/in_game/events/CapEcon_situation_events.txt
+++ b/in_game/events/CapEcon_situation_events.txt
@@ -25,8 +25,8 @@ cap_econ.20 = {
             value = 1
             if = {
                 limit = {
-                    has_variable = cap_econ_pantalone_happiness_modifier
-                    var:cap_econ_pantalone_happiness_modifier >= 1
+                    has_variable = pantalone_happiness_modifier
+                    var:pantalone_happiness_modifier >= 1
                 }
                 add = 1
             }
@@ -65,8 +65,8 @@ cap_econ.20 = {
             value = 1
             if = {
                 limit = {
-                    has_variable = cap_econ_pantalone_happiness_modifier
-                    var:cap_econ_pantalone_happiness_modifier <= 1
+                    has_variable = pantalone_happiness_modifier
+                    var:pantalone_happiness_modifier <= 1
                 }
                 add = 1
             }
@@ -94,29 +94,6 @@ cap_econ.20 = {
 
     }
 }
-cap_econ.21 = {
-    type = country_event
-    category = situation_event
-
-    title = cap_econ.21.title
-    desc = cap_econ.21.desc
-    image = "gfx/interface/illustrations/situation/reformation.dds"
-
-    trigger = {
-        always = no
-    }
-
-    option = {
-        name = cap_econ.21.a
-        custom_tooltip = cap_econ.21.a.tt
-        hidden_effect = {
-            situation:rise_of_pantalonism = {
-                change_variable = { name = pantalonism_progress add = -5 }
-            }
-        }
-    }
-}
-
 cap_econ.22 = {
     type = country_event
 
@@ -204,39 +181,6 @@ cap_econ.23 = {
     }
 }
 
-
-cap_econ.24 = {
-    type = country_event
-    category = situation_event
-
-    title = cap_econ.24.title
-    desc = cap_econ.24.desc
-    image = "gfx/interface/illustrations/situation/reformation.dds"
-
-    trigger = {
-    }
-
-    option = {
-        name = cap_econ.24.a
-        custom_tooltip = cap_econ.24.a.tt
-        every_owned_location = {
-            limit = { has_building_with_at_least_one_level = Mangiatoia }
-            set_variable = {
-                name = cap_econ_mangiatoia_loc_fraction
-                value = "location_building_level(building_type:Mangiatoia)"
-            }
-            change_variable = { name = cap_econ_mangiatoia_loc_fraction multiply = 0.005 }
-            every_pop = {
-                limit = { religion != religion:pantalonism }
-                split_pop = {
-                    fraction = var:cap_econ_mangiatoia_loc_fraction
-                    religion = religion:pantalonism
-                }
-            }
-            remove_variable = cap_econ_mangiatoia_loc_fraction
-        }
-    }
-}
 
 cap_econ.27 = {
     type = country_event
@@ -327,62 +271,6 @@ cap_econ.27 = {
         }
         situation:rise_of_pantalonism = {
             change_variable = { name = pantalone_happiness_modifier add = -1 }
-        }
-
-    }
-}
-
-cap_econ.28 = {
-    type = country_event
-    category = situation_event
-
-    title = cap_econ.27.title
-    desc = cap_econ.27.desc
-    image = "gfx/interface/illustrations/situation/reformation.dds"
-
-    trigger = {
-        situation:rise_of_pantalonism = {
-            var:pantalone_happiness_modifier >= 0
-        }
-    }
-
-    option = {
-        name = cap_econ.27.a
-        custom_tooltip = cap_econ.27.a.tt
-        add_stability = 10
-        add_gold = 500
-        # Build up to 3 Mangiatoia levels; if capital is full, try another location with room.
-        while = {
-            count = 3
-            if = {
-                limit = {
-                    any_owned_location = {
-                        is_capital = yes
-                        "location_building_level(building_type:Mangiatoia)" < 10
-                    }
-                }
-                every_owned_location = {
-                    limit = {
-                        is_capital = yes
-                        "location_building_level(building_type:Mangiatoia)" < 10
-                    }
-                    change_building_level_in_location = {
-                        building = building_type:Mangiatoia
-                        value = 1
-                    }
-                }
-            }
-            else = {
-                random_owned_location = {
-                    limit = {
-                        "location_building_level(building_type:Mangiatoia)" < 10
-                    }
-                    change_building_level_in_location = {
-                        building = building_type:Mangiatoia
-                        value = 1
-                    }
-                }
-            }
         }
 
     }

--- a/in_game/gui/panels/organization/cap_econ_pantalonist_io.gui
+++ b/in_game/gui/panels/organization/cap_econ_pantalonist_io.gui
@@ -250,8 +250,9 @@ organization_panel = {
 			hbox = {
 				layoutpolicy_horizontal = expanding
 				margin = {15 5}
-				using = members_entry
+				using = hre_members_entry
 			}
+			visible = "[Not( EqualTo_string(MemberTypeItem.GetName, ShowSpecialStatusName('emperor')) )]"
 			blockoverride "member_item_visibility"{
 				visible = "[Not( IsDataModelEmpty(MemberTypeItem.GetCountries) )]"
 			}
@@ -403,9 +404,9 @@ template hre_elector_flag_entry {
 									}
 								}
 							}
-					
+						
 							blockoverride "title_text" {
-								raw_text = "[Country.GetNameWithNoTooltip]'s Imperial Vote"
+								raw_text = "[Country.GetNameWithNoTooltip]'s League Vote"
 							}
 					
 							blockoverride "concept_link" {
@@ -440,7 +441,7 @@ template hre_elector_flag_entry {
 				autoresize = yes
 				tooltip_enabled = "[Country.IsValid]"
 				tooltipwidget = {
-					ContextualTooltipType = {
+						ContextualTooltipType = {
 						blockoverride "title_icon" {
 							icon = {
 								using = tooltip_title_icon_size
@@ -455,9 +456,9 @@ template hre_elector_flag_entry {
 							}
 						}
 				
-						blockoverride "title_text" {
-							text = "IMPERIAL_VOTE_TITLE"
-						}
+							blockoverride "title_text" {
+								text = "CAP_ECON_LEAGUE_VOTE_TITLE"
+							}
 				
 						blockoverride "concept_link" {
 							text = "[vote|e]"

--- a/main_menu/gui/CapEcon_messagetypes.txt
+++ b/main_menu/gui/CapEcon_messagetypes.txt
@@ -1,0 +1,49 @@
+﻿PERFORM_cap_econ_kill_pantalonism_rebels_ACTION={
+log=yes
+onmap=no
+popup=yes
+idle=no
+option=yes
+pausepopup=no
+message_category = military
+}
+
+PERFORM_cap_econ_fund_mangiatoia_ACTION={
+log=yes
+onmap=no
+popup=yes
+idle=no
+option=yes
+pausepopup=no
+message_category = economy
+}
+
+PERFORM_cap_econ_fund_mangiatoia_foreign_ACTION={
+log=yes
+onmap=no
+popup=yes
+idle=no
+option=yes
+pausepopup=no
+message_category = economy
+}
+
+PERFORM_cap_econ_bribe_the_estate_ACTION={
+log=yes
+onmap=no
+popup=yes
+idle=no
+option=yes
+pausepopup=no
+message_category = diplomacy
+}
+
+PERFORM_cap_econ_subsidize_conversion_ACTION={
+log=yes
+onmap=no
+popup=yes
+idle=no
+option=yes
+pausepopup=no
+message_category = religion
+}

--- a/main_menu/localization/english/CapEcon_international_organizations_l_english.yml
+++ b/main_menu/localization/english/CapEcon_international_organizations_l_english.yml
@@ -109,6 +109,7 @@
  CAP_ECON_IMPERIAL_LAWS_TITLE: "League Reform Framework"
  CAP_ECON_IMPERIAL_LAWS_DESC: "These laws define the constitutional and economic structure of the Pantalonist League, including its Diet, dividend system, and common defense rules."
  CAP_ECON_IMPERIAL_DIET: "Imperial Diet"
+ CAP_ECON_LEAGUE_VOTE_TITLE: "League Vote"
  CAP_ECON_VOTE_IO_LEADER_DESC: "Cast your vote in the current league leadership election."
  diplomatic_status_cap_econ_pantalonist_io_name: "Pantalonist League Member"
  diplomatic_status_cap_econ_pantalonist_io_tooltip: "This country is part of the Pantalonist League and follows its shared diplomatic framework."

--- a/main_menu/localization/english/CapEcon_international_organizations_l_english.yml
+++ b/main_menu/localization/english/CapEcon_international_organizations_l_english.yml
@@ -113,3 +113,4 @@
  diplomatic_status_cap_econ_pantalonist_io_name: "Pantalonist League Member"
  diplomatic_status_cap_econ_pantalonist_io_tooltip: "This country is part of the Pantalonist League and follows its shared diplomatic framework."
  cap_econ_pantalonist_io_list_who_tt: "Countries currently participating in the Pantalonist League."
+ io_opinion_cap_econ_pantalonist_io: "Fellow member of the Pantalonist League"

--- a/main_menu/localization/english/CapEcon_messages_l_english.yml
+++ b/main_menu/localization/english/CapEcon_messages_l_english.yml
@@ -1,0 +1,55 @@
+﻿l_english:
+# Maintainer Note:
+# - Purpose: CapEcon_messages_l_english.yml defines notification text for custom generic actions used by the mod.
+# - Reasoning: generic actions emit message types that must be localized explicitly to avoid runtime missing-message warnings.
+# - Maintenance: add matching PERFORM/WE_PERFORM/ACTION_* keys whenever a new action should notify the player.
+#
+ PERFORM_cap_econ_kill_pantalonism_rebels_ACTION_SETUP: "When a country launches a crackdown against Pantalonist rebels during the Rise of Pantalonism."
+ PERFORM_cap_econ_kill_pantalonism_rebels_ACTION_HEADER: "$MESSENGER$"
+ PERFORM_cap_econ_kill_pantalonism_rebels_ACTION_TITLE: "Pantalonist Rebels Targeted"
+ PERFORM_cap_econ_kill_pantalonism_rebels_ACTION_EFFECTS: "$EFFECT$"
+ PERFORM_cap_econ_kill_pantalonism_rebels_ACTION_LOG: "$PERFORM_cap_econ_kill_pantalonism_rebels_ACTION_TITLE$"
+ PERFORM_cap_econ_kill_pantalonism_rebels_ACTION_BTN1: "OK"
+ PERFORM_cap_econ_kill_pantalonism_rebels_ACTION_BTN2: "OK"
+ PERFORM_cap_econ_kill_pantalonism_rebels_ACTION_BTN3: "$common_string_go_to$"
+ PERFORM_cap_econ_kill_pantalonism_rebels_ACTION_MAP: ""
+
+ PERFORM_cap_econ_fund_mangiatoia_ACTION_SETUP: "When a Pantalonist patron funds a Mangiatoia during the Rise of Pantalonism."
+ PERFORM_cap_econ_fund_mangiatoia_ACTION_HEADER: "$MESSENGER$"
+ PERFORM_cap_econ_fund_mangiatoia_ACTION_TITLE: "Mangiatoia Funded"
+ PERFORM_cap_econ_fund_mangiatoia_ACTION_EFFECTS: "$EFFECT$"
+ PERFORM_cap_econ_fund_mangiatoia_ACTION_LOG: "$PERFORM_cap_econ_fund_mangiatoia_ACTION_TITLE$"
+ PERFORM_cap_econ_fund_mangiatoia_ACTION_BTN1: "OK"
+ PERFORM_cap_econ_fund_mangiatoia_ACTION_BTN2: "OK"
+ PERFORM_cap_econ_fund_mangiatoia_ACTION_BTN3: "$common_string_go_to$"
+ PERFORM_cap_econ_fund_mangiatoia_ACTION_MAP: ""
+
+ PERFORM_cap_econ_fund_mangiatoia_foreign_ACTION_SETUP: "When a foreign Pantalonist patron funds a Mangiatoia abroad during the Rise of Pantalonism."
+ PERFORM_cap_econ_fund_mangiatoia_foreign_ACTION_HEADER: "$MESSENGER$"
+ PERFORM_cap_econ_fund_mangiatoia_foreign_ACTION_TITLE: "Foreign Mangiatoia Funded"
+ PERFORM_cap_econ_fund_mangiatoia_foreign_ACTION_EFFECTS: "$EFFECT$"
+ PERFORM_cap_econ_fund_mangiatoia_foreign_ACTION_LOG: "$PERFORM_cap_econ_fund_mangiatoia_foreign_ACTION_TITLE$"
+ PERFORM_cap_econ_fund_mangiatoia_foreign_ACTION_BTN1: "OK"
+ PERFORM_cap_econ_fund_mangiatoia_foreign_ACTION_BTN2: "OK"
+ PERFORM_cap_econ_fund_mangiatoia_foreign_ACTION_BTN3: "$common_string_go_to$"
+ PERFORM_cap_econ_fund_mangiatoia_foreign_ACTION_MAP: ""
+
+ PERFORM_cap_econ_bribe_the_estate_ACTION_SETUP: "When a country bribes local estates to secure extraction privileges during the Rise of Pantalonism."
+ PERFORM_cap_econ_bribe_the_estate_ACTION_HEADER: "$MESSENGER$"
+ PERFORM_cap_econ_bribe_the_estate_ACTION_TITLE: "Estate Bribery"
+ PERFORM_cap_econ_bribe_the_estate_ACTION_EFFECTS: "$EFFECT$"
+ PERFORM_cap_econ_bribe_the_estate_ACTION_LOG: "$PERFORM_cap_econ_bribe_the_estate_ACTION_TITLE$"
+ PERFORM_cap_econ_bribe_the_estate_ACTION_BTN1: "OK"
+ PERFORM_cap_econ_bribe_the_estate_ACTION_BTN2: "OK"
+ PERFORM_cap_econ_bribe_the_estate_ACTION_BTN3: "$common_string_go_to$"
+ PERFORM_cap_econ_bribe_the_estate_ACTION_MAP: ""
+
+ PERFORM_cap_econ_subsidize_conversion_ACTION_SETUP: "When a Pantalonist state subsidizes conversion in a target country."
+ PERFORM_cap_econ_subsidize_conversion_ACTION_HEADER: "$MESSENGER$"
+ PERFORM_cap_econ_subsidize_conversion_ACTION_TITLE: "Conversion Subsidized"
+ PERFORM_cap_econ_subsidize_conversion_ACTION_EFFECTS: "$EFFECT$"
+ PERFORM_cap_econ_subsidize_conversion_ACTION_LOG: "$PERFORM_cap_econ_subsidize_conversion_ACTION_TITLE$"
+ PERFORM_cap_econ_subsidize_conversion_ACTION_BTN1: "OK"
+ PERFORM_cap_econ_subsidize_conversion_ACTION_BTN2: "OK"
+ PERFORM_cap_econ_subsidize_conversion_ACTION_BTN3: "$common_string_go_to$"
+ PERFORM_cap_econ_subsidize_conversion_ACTION_MAP: ""


### PR DESCRIPTION
## Summary
- initialize the Pantalonist League with explicit baseline policies so new leagues start with valid law states
- renumber leveled Pantalonist policies to progress from 0-based starter policies into 1, 2, 3 and higher upgrades
- clean up related validation issues, message registrations, and maintainer guidance discovered during testing