### PR TITLE
Fix/pantalonist io startup state for overview

### DIFF
--- a/in_game/common/laws/CapEcon_pantalonist_io_laws.txt
+++ b/in_game/common/laws/CapEcon_pantalonist_io_laws.txt
@@ -18,7 +18,10 @@ pantalone_stability_law = {
 	no_pantalone_stability_policy = {
 		level = 1
 		allow = {
-			international_organization_has_policy = policy:pantalone_stability_policy
+			OR = {
+				international_organization_has_policy = policy:no_pantalone_stability_policy
+				international_organization_has_policy = policy:pantalone_stability_policy
+			}
 		}
 		wants_this_policy_bias = {
 			subtract = {
@@ -32,7 +35,10 @@ pantalone_stability_law = {
 		level = 2
 		allow = {
 			var:pantalone_authority >= 1
-			international_organization_has_policy = policy:no_pantalone_stability_policy
+			OR = {
+				international_organization_has_policy = policy:no_pantalone_stability_policy
+				international_organization_has_policy = policy:pantalone_stability_policy
+			}
 		}
 		on_activate = {
 			change_variable = { name = pantalone_authority add = -1 }
@@ -71,7 +77,10 @@ pantalone_production_law = {
 	no_pantalone_production_policy = {
 		level = 1
 		allow = {
-			international_organization_has_policy = policy:pantalone_production_policy
+			OR = {
+				international_organization_has_policy = policy:no_pantalone_production_policy
+				international_organization_has_policy = policy:pantalone_production_policy
+			}
 		}
 		wants_this_policy_bias = {
 			subtract = {
@@ -85,7 +94,10 @@ pantalone_production_law = {
 		level = 2
 		allow = {
 			var:pantalone_authority >= 1
-			international_organization_has_policy = policy:no_pantalone_production_policy
+			OR = {
+				international_organization_has_policy = policy:no_pantalone_production_policy
+				international_organization_has_policy = policy:pantalone_production_policy
+			}
 		}
 		on_activate = {
 			change_variable = { name = pantalone_authority add = -1 }
@@ -123,7 +135,10 @@ pantalone_imperial_diet_law = {
 	no_pantalone_imperial_diet_policy = {
 		level = 1
 		allow = {
-			international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
+			OR = {
+				international_organization_has_policy = policy:no_pantalone_imperial_diet_policy
+				international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
+			}
 		}
 		on_activate = {
 			# Keep a minimal chamber active at level 1 so members can still initiate and vote on law reforms.
@@ -143,6 +158,7 @@ pantalone_imperial_diet_law = {
 			var:pantalone_authority >= 1
 			OR = {
 				international_organization_has_policy = policy:no_pantalone_imperial_diet_policy
+				international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
 				international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
 			}
 		}
@@ -170,6 +186,7 @@ pantalone_imperial_diet_law = {
 			var:pantalone_authority >= 1
 			OR = {
 				international_organization_has_policy = policy:pantalone_early_imperial_diet_policy
+				international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
 				international_organization_has_policy = policy:pantalone_tri_camerial_imperial_diet_policy
 			}
 		}
@@ -195,7 +212,10 @@ pantalone_imperial_diet_law = {
 		level = 4
 		allow = {
 			var:pantalone_authority >= 1
-			international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
+			OR = {
+				international_organization_has_policy = policy:pantalone_bi_camerial_imperial_diet_policy
+				international_organization_has_policy = policy:pantalone_tri_camerial_imperial_diet_policy
+			}
 		}
 		on_activate = {
 			change_variable = { name = pantalone_authority add = -1 }
@@ -231,7 +251,10 @@ pantalone_contribution_law = {
 	no_pantalone_contribution_policy = {
 		level = 1
 		allow = {
-			international_organization_has_policy = policy:pantalone_contribution_policy_1
+			OR = {
+				international_organization_has_policy = policy:no_pantalone_contribution_policy
+				international_organization_has_policy = policy:pantalone_contribution_policy_1
+			}
 		}
 		on_activate = {
 			set_variable = { name = contribution_modifier value = 20 }
@@ -250,6 +273,7 @@ pantalone_contribution_law = {
 			var:pantalone_authority >= 1
 			OR = {
 				international_organization_has_policy = policy:no_pantalone_contribution_policy
+				international_organization_has_policy = policy:pantalone_contribution_policy_1
 				international_organization_has_policy = policy:pantalone_contribution_policy_2
 			}
 		}
@@ -277,6 +301,7 @@ pantalone_contribution_law = {
 			var:pantalone_authority >= 1
 			OR = {
 				international_organization_has_policy = policy:pantalone_contribution_policy_1
+				international_organization_has_policy = policy:pantalone_contribution_policy_2
 				international_organization_has_policy = policy:pantalone_contribution_policy_3
 			}
 		}
@@ -304,6 +329,7 @@ pantalone_contribution_law = {
 			var:pantalone_authority >= 1
 			OR = {
 				international_organization_has_policy = policy:pantalone_contribution_policy_2
+				international_organization_has_policy = policy:pantalone_contribution_policy_3
 				international_organization_has_policy = policy:pantalone_contribution_policy_4
 			}
 		}
@@ -331,6 +357,7 @@ pantalone_contribution_law = {
 			var:pantalone_authority >= 1
 			OR = {
 				international_organization_has_policy = policy:pantalone_contribution_policy_3
+				international_organization_has_policy = policy:pantalone_contribution_policy_4
 				international_organization_has_policy = policy:pantalone_contribution_policy_5
 			}
 		}
@@ -356,7 +383,10 @@ pantalone_contribution_law = {
 		level = 6
 		allow = {
 			var:pantalone_authority >= 1
-			international_organization_has_policy = policy:pantalone_contribution_policy_4
+			OR = {
+				international_organization_has_policy = policy:pantalone_contribution_policy_4
+				international_organization_has_policy = policy:pantalone_contribution_policy_5
+			}
 		}
 		on_activate = {
 			change_variable = { name = pantalone_authority add = -1 }
@@ -392,7 +422,10 @@ pantalone_estate_contribution_law = {
 	no_pantalone_estate_contribution_policy = {
 		level = 1
 		allow = {
-			international_organization_has_policy = policy:pantalone_estate_contribution_policy_1
+			OR = {
+				international_organization_has_policy = policy:no_pantalone_estate_contribution_policy
+				international_organization_has_policy = policy:pantalone_estate_contribution_policy_1
+			}
 		}
 		on_activate = {
 			set_variable = { name = estate_contribution_modifier value = 10 }
@@ -411,6 +444,7 @@ pantalone_estate_contribution_law = {
 			var:pantalone_authority >= 1
 			OR = {
 				international_organization_has_policy = policy:no_pantalone_estate_contribution_policy
+				international_organization_has_policy = policy:pantalone_estate_contribution_policy_1
 				international_organization_has_policy = policy:pantalone_estate_contribution_policy_2
 			}
 		}
@@ -438,6 +472,7 @@ pantalone_estate_contribution_law = {
 			var:pantalone_authority >= 1
 			OR = {
 				international_organization_has_policy = policy:pantalone_estate_contribution_policy_1
+				international_organization_has_policy = policy:pantalone_estate_contribution_policy_2
 				international_organization_has_policy = policy:pantalone_estate_contribution_policy_3
 			}
 		}
@@ -465,6 +500,7 @@ pantalone_estate_contribution_law = {
 			var:pantalone_authority >= 1
 			OR = {
 				international_organization_has_policy = policy:pantalone_estate_contribution_policy_2
+				international_organization_has_policy = policy:pantalone_estate_contribution_policy_3
 				international_organization_has_policy = policy:pantalone_estate_contribution_policy_4
 			}
 		}
@@ -490,7 +526,10 @@ pantalone_estate_contribution_law = {
 		level = 5
 		allow = {
 			var:pantalone_authority >= 1
-			international_organization_has_policy = policy:pantalone_estate_contribution_policy_3
+			OR = {
+				international_organization_has_policy = policy:pantalone_estate_contribution_policy_3
+				international_organization_has_policy = policy:pantalone_estate_contribution_policy_4
+			}
 		}
 		on_activate = {
 			change_variable = { name = pantalone_authority add = -1 }
@@ -526,7 +565,10 @@ pantalone_leader_payment_law = {
 	pantalone_leader_exempt_policy = {
 		level = 1
 		allow = {
-			international_organization_has_policy = policy:pantalone_leader_pays_policy
+			OR = {
+				international_organization_has_policy = policy:pantalone_leader_exempt_policy
+				international_organization_has_policy = policy:pantalone_leader_pays_policy
+			}
 		}
 		wants_this_policy_bias = {
 			add = {
@@ -540,7 +582,10 @@ pantalone_leader_payment_law = {
 		level = 2
 		allow = {
 			var:pantalone_authority >= 5
-			international_organization_has_policy = policy:pantalone_leader_exempt_policy
+			OR = {
+				international_organization_has_policy = policy:pantalone_leader_exempt_policy
+				international_organization_has_policy = policy:pantalone_leader_pays_policy
+			}
 		}
 		on_activate = {
 			change_variable = { name = pantalone_authority add = -5 }
@@ -572,9 +617,6 @@ pantalone_redistribution_law = {
 	locked = { }
 
 	pantalone_dividends_leader_policy = {
-		allow = {
-			NOT = { international_organization_has_policy = policy:pantalone_dividends_leader_policy }
-		}
 		wants_propose_policy = {
 			subtract = {
 				desc = "DIPLOREASON_BASE"
@@ -590,9 +632,6 @@ pantalone_redistribution_law = {
 	}
 
 	pantalone_dividends_equal_policy = {
-		allow = {
-			NOT = { international_organization_has_policy = policy:pantalone_dividends_equal_policy }
-		}
 		wants_propose_policy = {
 			add = {
 				desc = "DIPLOREASON_BASE"
@@ -608,9 +647,6 @@ pantalone_redistribution_law = {
 	}
 
 	pantalone_dividends_split_policy = {
-		allow = {
-			NOT = { international_organization_has_policy = policy:pantalone_dividends_split_policy }
-		}
 		wants_propose_policy = {
 			subtract = {
 				desc = "DIPLOREASON_BASE"
@@ -641,7 +677,10 @@ pantalone_defense_law = {
 	no_pantalone_defense_policy = {
 		level = 1
 		allow = {
-			international_organization_has_policy = policy:pantalone_defense_manual_policy
+			OR = {
+				international_organization_has_policy = policy:no_pantalone_defense_policy
+				international_organization_has_policy = policy:pantalone_defense_manual_policy
+			}
 		}
 		wants_this_policy_bias = {
 			subtract = {
@@ -657,6 +696,7 @@ pantalone_defense_law = {
 			var:pantalone_authority >= 1
 			OR = {
 				international_organization_has_policy = policy:no_pantalone_defense_policy
+				international_organization_has_policy = policy:pantalone_defense_manual_policy
 				international_organization_has_policy = policy:pantalone_defense_auto_policy
 			}
 		}
@@ -688,7 +728,10 @@ pantalone_defense_law = {
 		level = 3
 		allow = {
 			var:pantalone_authority >= 1
-			international_organization_has_policy = policy:pantalone_defense_manual_policy
+			OR = {
+				international_organization_has_policy = policy:pantalone_defense_manual_policy
+				international_organization_has_policy = policy:pantalone_defense_auto_policy
+			}
 		}
 		diplomatic_capacity_cost = automatic_defence_upkeep_cost
 		join_defensive_wars_auto_call = {

--- a/in_game/events/CapEcon_io_events.txt
+++ b/in_game/events/CapEcon_io_events.txt
@@ -34,7 +34,7 @@ cap_econ_io.1 = {
         }
         else = {
             international_organization:cap_econ_pantalonist_io = {
-                add_country_to_international_organization_no_update = scope:pantalone_joiner
+                add_country_to_international_organization = scope:pantalone_joiner
                 if = {
                     limit = { international_organization_has_leader = no }
                     if = {

--- a/in_game/gui/panels/organization/cap_econ_pantalonist_io.gui
+++ b/in_game/gui/panels/organization/cap_econ_pantalonist_io.gui
@@ -4,6 +4,17 @@
 # - Maintenance: keep widget names and bound scripted values synchronized with situation/event data providers.
 
 organization_panel = {
+	blockoverride "organization_overview_tab_visible" {}
+	blockoverride "organization_panel_overview_visible" {
+		visible = "[InternationalOrganizationsView.Vars.NotExistOrHasValue( 'organizations', 'overview' )]"
+	}
+	blockoverride "organization_members_tab_down" {
+		down = "[InternationalOrganizationsView.Vars.HasValue( 'organizations', 'members' )]"
+	}
+	blockoverride "organization_panel_members_visible" {
+		visible = "[InternationalOrganizationsView.Vars.HasValue( 'organizations', 'members' )]"
+	}
+
 	blockoverride "organization_panel_middle_botton" {
 		
 	}

--- a/in_game/gui/panels/organization/cap_econ_pantalonist_io.gui
+++ b/in_game/gui/panels/organization/cap_econ_pantalonist_io.gui
@@ -49,14 +49,11 @@ organization_panel = {
 	blockoverride "organization_overview_list_bg" { spacing = 5 }
 	blockoverride "organization_main_actions_extra_visible" { visible = yes }
 	blockoverride "organization_overview_filtered_list" {
+		margin_top = 5
 		filtered_sorted_list = {
-			block "organization_overview_filtered_list_type" {
-				datacontext = "[InternationalOrganizationsView.GetSpecialMembersSortSearch]"
-				blockoverride "scroll_list_is_empty" {
-					block "scroll_overview_empty_visible" {
-						visible = "[IsDataModelEmpty(InternationalOrganizationsView.GetSpecialMemberItems)]"
-					}
-				}
+			datacontext = "[InternationalOrganizationsView.GetMembersSortSearch]"
+			blockoverride "scroll_list_is_empty" {
+				visible = "[IsDataModelEmpty(InternationalOrganizationsView.GetMemberItems)]"
 			}
 			blockoverride "scroll_list_is_empty_text" {
 				text = "MEMBERS_SCROLL_LIST_EMPTY"
@@ -152,7 +149,7 @@ organization_panel = {
 
 					vbox = {
 						layoutpolicy_horizontal = expanding
-						datamodel = "[InternationalOrganizationsView.GetSpecialMemberItems]"
+						datamodel = "[InternationalOrganizationsView.GetMemberItems]"
 						item = {
 							block "organization_overview_list_item" {
 								vbox = {

--- a/in_game/gui/panels/organization/cap_econ_pantalonist_io.gui
+++ b/in_game/gui/panels/organization/cap_econ_pantalonist_io.gui
@@ -162,12 +162,59 @@ organization_panel = {
 						layoutpolicy_horizontal = expanding
 						datamodel = "[InternationalOrganizationsView.GetMemberItems]"
 						item = {
-							block "organization_overview_list_item" {
-								vbox = {
-									layoutpolicy_horizontal = expanding
-									spacing = 10
-									using = members_entry
-									visible = "[Not(IsDataModelEmpty(MemberTypeItem.GetCountries))]"
+							estates_summary = {
+								visible = "[And(Not(IsDataModelEmpty(MemberTypeItem.GetCountries)), MemberTypeItem.IsAllMembers)]"
+								blockoverride "summary_datamodel" {
+									datamodel = "[MemberTypeItem.GetCountries]"
+								}
+								blockoverride "header_content" {
+									tagtooltip_enabled = yes
+									tooltipwidget = {
+										ContextualTooltipType = {
+											blockoverride "title_icon" {
+												icon = {
+													using = tooltip_title_icon_size
+													texture = "[MemberTypeItem.GetIcon]"
+												}
+											}
+											blockoverride "title_text" {
+												text = "[MemberTypeItem.GetName]"
+											}
+											blockoverride "concept_link" {
+												text = "[international_organization|e]"
+											}
+											blockoverride "tooltip_content" {
+												TooltipTextBlock = {
+													blockoverride "text" {
+														text = "INTERNATIONAL_ORGANIZATION_TT_MEMBER"
+													}
+												}
+											}
+										}
+									}
+									vbox = {
+										autoresize = yes
+										layoutpolicy_horizontal = expanding
+										hbox = {
+											layoutpolicy_horizontal = expanding
+											icon = {
+												size = { 25 25 }
+												texture = "[MemberTypeItem.GetIcon]"
+												texture_density = 2
+												glow = {
+													name = "drop_shadow"
+													glow_radius = 3
+													color = {0.0 0.0 0.0 1.0}
+													alpha = 0.5
+												}
+											}
+											text_single = {
+												layoutpolicy_horizontal = expanding
+												autoresize = no
+												raw_text = "[MemberTypeItem.GetMembersAmount] [MemberTypeItem.GetName]"
+											}
+										}
+									}
 								}
 							}
 						}

--- a/in_game/gui/panels/organization/cap_econ_pantalonist_io.gui
+++ b/in_game/gui/panels/organization/cap_econ_pantalonist_io.gui
@@ -4,6 +4,10 @@
 # - Maintenance: keep widget names and bound scripted values synchronized with situation/event data providers.
 
 organization_panel = {
+	blockoverride "organization_panel_middle_botton" {
+		
+	}
+
 	blockoverride "io_decoration" {
 		allow_outside = yes
 		icon = {
@@ -44,6 +48,128 @@ organization_panel = {
 
 	blockoverride "organization_overview_list_bg" { spacing = 5 }
 	blockoverride "organization_main_actions_extra_visible" { visible = yes }
+	blockoverride "organization_overview_filtered_list" {
+		filtered_sorted_list = {
+			block "organization_overview_filtered_list_type" {
+				datacontext = "[InternationalOrganizationsView.GetSpecialMembersSortSearch]"
+				blockoverride "scroll_list_is_empty" {
+					block "scroll_overview_empty_visible" {
+						visible = "[IsDataModelEmpty(InternationalOrganizationsView.GetSpecialMemberItems)]"
+					}
+				}
+			}
+			blockoverride "scroll_list_is_empty_text" {
+				text = "MEMBERS_SCROLL_LIST_EMPTY"
+			}
+			blockoverride "scroll_list_layout" {
+				vbox = {
+					block "organization_overview_list_bg" {
+						using = layoutpolicy_expanding
+						using = bg_secondary_inner_alt
+						margin_bottom = 20
+						spacing = 5
+					}
+					vbox = {
+						layoutpolicy_horizontal = expanding
+						margin = { 10 2 }
+						spacing = 10
+
+						block "organization_overview_list_custom_top_extra" {}
+						card_actions = {
+							block "organization_main_actions_extra_visible" { visible = "[InternationalOrganizationsView.HasActions]" }
+							blockoverride "card_header_text" {
+								text = "MAIN_ACTIONS"
+							}
+							blockoverride "card_header_icon" {
+								block "io_main_actions_icon" {
+									texture = "[InternationalOrganization.GetIcon]"
+								}
+							}
+
+							blockoverride "actions_override" {
+								vbox = {
+									spacing = 2
+									layoutpolicy_horizontal = expanding
+									scrollarea = {
+										maximumsize = { 470 400 }
+										scrollbarpolicy_horizontal = always_off
+										autoresizescrollarea = yes
+										scrollbar_vertical = {
+											using = Scrollbar_Vertical
+										}
+										scrollwidget = {
+											dynamicgridbox = {
+												datamodel = "[InternationalOrganizationsView.GetActions]"
+												item = {
+													widget = {
+														size = { 470 37 }
+														action_button_diamond = {
+															parentanchor = center
+															visible = "[Not(EqualTo_string(GenericAction.GetKey, 'contribute_to_organization_treasury'))]"
+															size = { 470 30 }
+															text = "[GenericAction.GetNameWithNoTooltip]"
+															title = "[GenericAction.GetNameWithNoTooltip]"
+															actor = "[InternationalOrganizationsView.GetPlayer]"
+															parameter = {
+																parameter_name = "recipient"
+																parameter_value = "[InternationalOrganizationsView.GetInternationalOrganization]"
+															}
+															left_action = { action_name = "[GenericAction.GetKey]" }
+															tooltipwidget = {
+																using = io_generic_action_button_tooltip
+															}
+														}
+													}
+												}
+											}
+										}
+									}
+									scrollarea = {
+										block "organization_main_actions_extra_visible" { visible = no }
+										maximumsize = { 470 400 }
+										scrollbarpolicy_horizontal = always_off
+										autoresizescrollarea = yes
+										scrollbar_vertical = {
+											using = Scrollbar_Vertical
+										}
+										scrollwidget = {
+											widget = {
+												vbox = {
+													set_parent_size_to_minimum = yes
+													margin = { 0 5 }
+													ignoreinvisible = yes
+													spacing = 6
+													block "organization_main_actions_extra" {}
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+						card_io_payments = {}
+					}
+
+					vbox = {
+						layoutpolicy_horizontal = expanding
+						datamodel = "[InternationalOrganizationsView.GetSpecialMemberItems]"
+						item = {
+							block "organization_overview_list_item" {
+								vbox = {
+									layoutpolicy_horizontal = expanding
+									spacing = 10
+									using = members_entry
+									visible = "[Not(IsDataModelEmpty(MemberTypeItem.GetCountries))]"
+								}
+							}
+						}
+					}
+
+					block "organization_overview_list_custom_bottom" {}
+				}
+			}
+		}
+	}
 	blockoverride "organization_overview_list_custom_top_extra" {
 		card_expandable = {
 			blockoverride "card_expandable_size" {
@@ -252,9 +378,7 @@ organization_panel = {
 			}
 		}
 	}
-	blockoverride "organization_overview_list_custom_bottom" {
-		card_io_payments = {}
-	}
+	blockoverride "organization_overview_list_custom_bottom" {}
 
 	blockoverride "abilities_margins_ios" {
 		margin_left = 45

--- a/in_game/gui/panels/organization/cap_econ_pantalonist_io.gui
+++ b/in_game/gui/panels/organization/cap_econ_pantalonist_io.gui
@@ -4,12 +4,6 @@
 # - Maintenance: keep widget names and bound scripted values synchronized with situation/event data providers.
 
 organization_panel = {
-
-	blockoverride "organization_panel_middle_botton" {
-		
-	}
-
-
 	blockoverride "io_decoration" {
 		allow_outside = yes
 		icon = {
@@ -258,7 +252,9 @@ organization_panel = {
 			}
 		}
 	}
-	blockoverride "organization_overview_list_custom_bottom" {}
+	blockoverride "organization_overview_list_custom_bottom" {
+		card_io_payments = {}
+	}
 
 	blockoverride "abilities_margins_ios" {
 		margin_left = 45

--- a/in_game/gui/panels/situation/rise_of_pantalonism.gui
+++ b/in_game/gui/panels/situation/rise_of_pantalonism.gui
@@ -171,6 +171,7 @@ situation_panel = {
                             SimpleContextualTooltipType = {
                                 lowpriotextcontext = "CAP_ECON_PANTALONISM_PROGRESS_TT"
                             }
+
                         }
                     }
                     progressbar = {


### PR DESCRIPTION
This pull request updates several laws and UI logic related to the Pantalonist International Organization to improve how policy prerequisites are checked and how the organization panel is displayed. The main changes enhance the flexibility and consistency of law progression by allowing multiple relevant international organization policies to satisfy law requirements, and they refine the organization panel's tab visibility logic in the GUI.

**Law prerequisite logic improvements:**

* Updated the `allow` conditions for all major Pantalonist IO laws (stability, production, imperial diet, contribution, estate contribution, leader payment, defense) to use `OR` blocks, allowing progression if any of several related international organization policies are active, rather than just one. This makes law advancement more robust and less likely to get blocked by policy mismatches. [[1]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R21-R25) [[2]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R38-R41) [[3]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R80-R84) [[4]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R97-R100) [[5]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R138-R142) [[6]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R161) [[7]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R189) [[8]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R215-R218) [[9]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R254-R258) [[10]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R276) [[11]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R304) [[12]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R332) [[13]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R360) [[14]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R386-R389) [[15]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R425-R429) [[16]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R447) [[17]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R475) [[18]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R503) [[19]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R529-R532) [[20]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R568-R572) [[21]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R585-R588) [[22]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R680-R684) [[23]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R699) [[24]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1R731-R734)

* Removed restrictive `allow` blocks from the redistribution law policies (`pantalone_dividends_leader_policy`, `pantalone_dividends_equal_policy`, `pantalone_dividends_split_policy`), likely to make them always available for proposal regardless of current IO policy. [[1]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1L575-L577) [[2]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1L593-L595) [[3]](diffhunk://#diff-f5ddfda171fb31c0e9505ac7f2035e2729b431682bbf20398b74707b8f0728d1L611-L613)

**Event and GUI logic updates:**

* Changed the event command from `add_country_to_international_organization_no_update` to `add_country_to_international_organization`, ensuring that the organization state is updated immediately when a country joins.

* Improved the organization panel GUI by adding block overrides for tab visibility and selection. This makes sure the correct tabs ("overview", "members") are shown or marked as active based on the current UI state, providing a more responsive and accurate user experience.